### PR TITLE
Fix the order of slots in BoxCornerEncoding

### DIFF
--- a/src/cpp/bbox_utils.h
+++ b/src/cpp/bbox_utils.h
@@ -21,10 +21,10 @@ namespace coral {
 // xmin = xcenter - half_w
 // xmax = xcenter + half_w
 struct BoxCornerEncoding {
-  float ymin;
   float xmin;
-  float ymax;
+  float ymin;
   float xmax;
+  float ymax;
 
   inline std::string DebugString() const {
     return absl::Substitute("ymin=$0,xmin=$1,ymax=$2,xmax=$3", ymin, xmin, ymax,


### PR DESCRIPTION
I found the order of  slots in [BoxCornerEncoding](https://github.com/google-coral/edgetpu/blob/master/src/cpp/bbox_utils.h#L23-L27) does not  correspond to the usage like [here](https://github.com/google-coral/edgetpu/blob/master/src/cpp/detection/engine.cc#L41).

So I correct the order according to the [python version](https://github.com/google-coral/edgetpu/blob/master/edgetpu/detection/engine.py#L44).