### PR TITLE
fix C2397 isuue when build edgetpu on windows

### DIFF
--- a/src/cpp/bbox_utils_test.cc
+++ b/src/cpp/bbox_utils_test.cc
@@ -6,45 +6,45 @@
 namespace coral {
 
 TEST(BboxTest, IsBoxEmpty) {
-  EXPECT_TRUE(IsBoxEmpty({0.7, 0.1, 0.5, 0.3}));
-  EXPECT_TRUE(IsBoxEmpty({0.5, 0.3, 0.7, 0.1}));
-  EXPECT_FALSE(IsBoxEmpty({0.5, 0.1, 0.7, 0.3}));
+  EXPECT_TRUE(IsBoxEmpty({0.7f, 0.1f, 0.5f, 0.3f}));
+  EXPECT_TRUE(IsBoxEmpty({0.5f, 0.3f, 0.7f, 0.1f}));
+  EXPECT_FALSE(IsBoxEmpty({0.5f, 0.1f, 0.7f, 0.3f}));
 }
 
 TEST(BboxTest, ComputeBoxArea) {
-  EXPECT_FLOAT_EQ(0, ComputeBoxArea({0.7, 0.1, 0.5, 0.3}));
-  EXPECT_FLOAT_EQ(0.06, ComputeBoxArea({0.5, 0.1, 0.7, 0.4}));
+  EXPECT_FLOAT_EQ(0, ComputeBoxArea({0.7f, 0.1f, 0.5f, 0.3f}));
+  EXPECT_FLOAT_EQ(0.06, ComputeBoxArea({0.5f, 0.1f, 0.7f, 0.4f}));
 }
 
 TEST(BboxTest, IntersectionOverUnion) {
   EXPECT_FLOAT_EQ(
-      0.5, IntersectionOverUnion({0.1, 0.2, 0.5, 0.4}, {0.1, 0.2, 0.3, 0.4}));
+      0.5f, IntersectionOverUnion({0.1f, 0.2f, 0.5f, 0.4f}, {0.1f, 0.2f, 0.3f, 0.4f}));
   EXPECT_FLOAT_EQ(
-      0.5, IntersectionOverUnion({0.1, 0.2, 0.5, 0.4}, {0.1, 0.2, 0.5, 0.3}));
+      0.5f, IntersectionOverUnion({0.1f, 0.2f, 0.5f, 0.4f}, {0.1f, 0.2f, 0.5f, 0.3f}));
   EXPECT_FLOAT_EQ(
-      0.6, IntersectionOverUnion({0.1, 0.2, 0.5, 0.4}, {0.2, 0.2, 0.6, 0.4}));
+      0.6f, IntersectionOverUnion({0.1f, 0.2f, 0.5f, 0.4f}, {0.2f, 0.2f, 0.6f, 0.4f}));
   EXPECT_FLOAT_EQ(
-      0.0, IntersectionOverUnion({0.1, 0.2, 0.5, 0.4}, {0.6, 0.2, 0.9, 0.4}));
+      0.0f, IntersectionOverUnion({0.1f, 0.2f, 0.5f, 0.4f}, {0.6f, 0.2f, 0.9f, 0.4f}));
 }
 
 TEST(DetectionCandidateTest, CompareDetectionCandidate) {
-  DetectionCandidate a{BoxCornerEncoding({0.0, 0.0, 1.0, 1.0}), 1, 0.2},
-      b{BoxCornerEncoding({0.0, 0.0, 1.0, 1.0}), 1, 0.5};
+  DetectionCandidate a{BoxCornerEncoding({0.0f, 0.0f, 1.0f, 1.0f}), 1, 0.2f},
+      b{BoxCornerEncoding({0.0f, 0.0f, 1.0f, 1.0f}), 1, 0.5f};
   // Equal.
   EXPECT_TRUE(a == DetectionCandidate(
-                       {BoxCornerEncoding({0.0, 0.0, 1.0, 1.0}), 1, 0.2}));
+                       {BoxCornerEncoding({0.0f, 0.0f, 1.0f, 1.0f}), 1, 0.2f}));
   EXPECT_FALSE(a == DetectionCandidate(
-                        {BoxCornerEncoding({0.1, 0.1, 1.0, 1.0}), 1, 0.2}));
+                        {BoxCornerEncoding({0.1f, 0.1f, 1.0f, 1.0f}), 1, 0.2f}));
   EXPECT_FALSE(a == DetectionCandidate(
-                        {BoxCornerEncoding({0.0, 0.0, 0.9, 0.9}), 1, 0.2}));
+                        {BoxCornerEncoding({0.0f, 0.0f, 0.9f, 0.9f}), 1, 0.2f}));
   EXPECT_FALSE(a == DetectionCandidate(
-                        {BoxCornerEncoding({0.0, 0.0, 1.0, 1.0}), 1, 0.19}));
+                        {BoxCornerEncoding({0.0f, 0.0f, 1.0f, 1.0f}), 1, 0.19f}));
   EXPECT_FALSE(a == DetectionCandidate(
-                        {BoxCornerEncoding({0.0, 0.0, 1.0, 1.0}), 2, 0.2}));
+                        {BoxCornerEncoding({0.0f, 0.0f, 1.0f, 1.0f}), 2, 0.2f}));
   EXPECT_TRUE(a != b);
   EXPECT_FALSE(a == b);
   // Assign.
-  DetectionCandidate tmp{BoxCornerEncoding({0.0, 0.0, 0.0, 0.0}), 5, 0.7};
+  DetectionCandidate tmp{BoxCornerEncoding({0.0f, 0.0f, 0.0f, 0.0f}), 5, 0.7f};
   EXPECT_TRUE(a != tmp);
   tmp = a;
   EXPECT_TRUE(a == tmp);

--- a/src/cpp/detection/models_test.cc
+++ b/src/cpp/detection/models_test.cc
@@ -16,46 +16,46 @@ TEST(DetectionEngineTest, TestSSDModelsWithCat) {
   // 4: number of detected objects;
   TestCatMsCocoDetection(
       TestDataPath("ssd_mobilenet_v1_coco_quant_postprocess.tflite"),
-      /*score_threshold=*/0.79, /*iou_threshold=*/0.8);
+      /*score_threshold=*/0.79f, /*iou_threshold=*/0.8f);
   TestCatMsCocoDetection(
       TestDataPath("ssd_mobilenet_v1_coco_quant_postprocess_edgetpu.tflite"),
-      /*score_threshold=*/0.79, /*iou_threshold=*/0.8);
+      /*score_threshold=*/0.79f, /*iou_threshold=*/0.8f);
 
   // Mobilenet V2 SSD
   TestCatMsCocoDetection(
       TestDataPath("ssd_mobilenet_v2_coco_quant_postprocess.tflite"),
-      /*score_threshold=*/0.95, /*iou_threshold=*/0.86);
+      /*score_threshold=*/0.95f, /*iou_threshold=*/0.86f);
   TestCatMsCocoDetection(
       TestDataPath("ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite"),
-      /*score_threshold=*/0.96, /*iou_threshold=*/0.86);
+      /*score_threshold=*/0.96f, /*iou_threshold=*/0.86f);
 }
 
 void TestFaceDetection(const std::string& model_name, float score_threshold,
                        float iou_threshold) {
   TestDetection(TestDataPath(model_name), TestDataPath("grace_hopper.bmp"),
-                /*expected_box=*/{0.29, 0.21, 0.74, 0.57}, /*expected_label=*/0,
+                /*expected_box=*/{0.29f, 0.21f, 0.74f, 0.57f}, /*expected_label=*/0,
                 score_threshold, iou_threshold);
 }
 
 TEST(DetectionEngineTest, TestFaceModel) {
   TestFaceDetection("ssd_mobilenet_v2_face_quant_postprocess.tflite", 0.7,
-                    0.65);
+                    0.65f);
   TestFaceDetection("ssd_mobilenet_v2_face_quant_postprocess_edgetpu.tflite",
-                    0.7, 0.65);
+                    0.7f, 0.65f);
 }
 
 TEST(DetectionEngineTest, TestFineTunedPetModel) {
   TestDetection(TestDataPath("ssd_mobilenet_v1_fine_tuned_pet.tflite"),
                 TestDataPath("cat.bmp"),
-                /*expected_box=*/{0.35, 0.11, 0.7, 0.66},
+                /*expected_box=*/{0.35f, 0.11f, 0.7f, 0.66f},
                 /*expected_label=*/0, /*score_threshold=*/0.9,
-                /*iou_threshold=*/0.81);
+                /*iou_threshold=*/0.81f);
 
   TestDetection(TestDataPath("ssd_mobilenet_v1_fine_tuned_pet_edgetpu.tflite"),
                 TestDataPath("cat.bmp"),
-                /*expected_box=*/{0.35, 0.11, 0.7, 0.66},
-                /*expected_label=*/0, /*score_threshold=*/0.9,
-                /*iou_threshold=*/0.81);
+                /*expected_box=*/{0.35f, 0.11f, 0.7f, 0.66f},
+                /*expected_label=*/0, /*score_threshold=*/0.9f,
+                /*iou_threshold=*/0.81f);
 }
 
 }  // namespace

--- a/src/cpp/posenet/posenet_decoder_test.cc
+++ b/src/cpp/posenet/posenet_decoder_test.cc
@@ -20,7 +20,7 @@ using ::testing::Pointwise;
 namespace coral {
 
 TEST(DecreasingArgSortTest, UnsortedVector) {
-  std::vector<float> scores = {0.6, 0.897, 0.01, 0.345, 0.28473};
+  std::vector<float> scores = {0.6f, 0.897f, 0.01f, 0.345f, 0.28473f};
   std::vector<int> indices(scores.size());
 
   DecreasingArgSort(scores, &indices);
@@ -28,7 +28,7 @@ TEST(DecreasingArgSortTest, UnsortedVector) {
 }
 
 TEST(DecreasingArgSortTest, AllSameVector) {
-  std::vector<float> scores = {0.5, 0.5, 0.5, 0.5, 0.5};
+  std::vector<float> scores = {0.5f, 0.5f, 0.5f, 0.5f, 0.5f};
   std::vector<int> indices(scores.size());
 
   DecreasingArgSort(scores, &indices);
@@ -36,7 +36,7 @@ TEST(DecreasingArgSortTest, AllSameVector) {
 }
 
 TEST(DecreasingArgSortTest, NegativeVector) {
-  std::vector<float> scores = {0.6, -0.897, 0.01, 0.345, 0.28473};
+  std::vector<float> scores = {0.6f, -0.897f, 0.01f, 0.345f, 0.28473f};
   std::vector<int> indices(scores.size());
 
   DecreasingArgSort(scores, &indices);
@@ -58,9 +58,9 @@ TEST(SigmoidTest, NegativeFive) { EXPECT_FLOAT_EQ(Sigmoid(-5), 0.006692851f); }
 
 TEST(LogoddsTest, NegativeNumber) { EXPECT_TRUE(std::isnan(Logodds(-1))); }
 
-TEST(LogoddsTest, Zero) { EXPECT_FLOAT_EQ(Logodds(0), -13.81551); }
+TEST(LogoddsTest, Zero) { EXPECT_FLOAT_EQ(Logodds(0), -13.81551f); }
 
-TEST(LogoddsTest, FiveTenths) { EXPECT_FLOAT_EQ(Logodds(0.5), 0.000004); }
+TEST(LogoddsTest, FiveTenths) { EXPECT_FLOAT_EQ(Logodds(0.5f), 0.000004f); }
 
 TEST(BuildLinearInterpolationTest, BuildYIsValid) {
   const int height = 3;
@@ -171,7 +171,7 @@ TEST(FindDisplacedPositionTest, PositionIsCorrectAllZeros) {
   float short_offsets[height * width * num_keypoints * 2] = {};
   // Create a mid_offsets tensor with all 0s
   float mid_offsets[height * width * 2 * 2 * num_edges] = {};
-  Point source{4.1, 3.5};
+  Point source{4.1f, 3.5f};
   const int edge_id = 1;
   const int target_id = 2;
 
@@ -200,7 +200,7 @@ TEST(FindDisplacedPositionTest, PositionIsCorrectAllOnes) {
   // Create a mid_offsets tensor with all -1s
   float mid_offsets[height * width * 2 * 2 * num_edges];
   std::fill(std::begin(mid_offsets), std::end(mid_offsets), -1.0f);
-  Point source{4.1, 3.5};
+  Point source{4.1f, 3.5f};
   const int edge_id = 1;
   const int target_id = 2;
 
@@ -253,16 +253,16 @@ TEST(FindDisplacedPositionTest, PositionIsCorrect) {
       }
     }
   }
-  Point source{4.1, 3.5};
+  Point source{4.1f, 3.5f};
   const int edge_id = 1;
   const int target_id = 2;
   // Make array of expected keypoints based on parameter i that
   // will be passed to FindDisplacedPosition (below)
   Point expected_points[] = {
-      Point{4.161290, 3.819355},
-      Point{4.639046, 4.439290},
-      Point{5.168825, 5.111249},
-      Point{5.755558, 5.840163},
+      Point{4.161290f, 3.819355f},
+      Point{4.639046f, 4.439290f},
+      Point{5.168825f, 5.111249f},
+      Point{5.755558f, 5.840163f},
   };
 
   for (int i = 0; i < 4; i++) {
@@ -320,8 +320,8 @@ TEST(BacktrackDecodePose, BacktrackDecodePoseIsCorrect) {
   PoseKeypoints pose_keypoints[num_keypoints];
   PoseKeypointScores keypoint_scores[num_keypoints];
 
-  const float y1 = 7.1;
-  const float x1 = 5.5;
+  const float y1 = 7.1f;
+  const float x1 = 5.5f;
   KeypointWithScore root(Point{y1, x1}, /*id=*/1, /*score=*/0);
   // score is a filler, will be set in BacktrackDecodePose
 
@@ -420,13 +420,13 @@ TEST(PassKeypointNMSTest, SquaredDistanceLessThanSquaredNMSRadius) {
   PoseKeypoints pose_keypoints[num_keypoints];
   pose_keypoints->keypoint[0] = Point{0, 0};
   pose_keypoints->keypoint[1] = Point{1, 1};
-  KeypointWithScore keypoint1(Point{0.5, 0.5}, /*id=*/0, /*score=*/0);
+  KeypointWithScore keypoint1(Point{0.5f, 0.5f}, /*id=*/0, /*score=*/0);
   // score doesn't matter here. Function doesn't check the score
   // The squared distance of this keypoint to previously detected keypoints is
   // min(0.5, 0.5) = 0.50
 
   EXPECT_FALSE(PassKeypointNMS(pose_keypoints, num_keypoints, keypoint1,
-                               /*squared_nms_radius=*/0.55));
+                               /*squared_nms_radius=*/0.55f));
 }
 
 TEST(PassKeypointNMSTest, SquaredDistanceGreaterThanSquaredNMSRadius) {
@@ -434,13 +434,13 @@ TEST(PassKeypointNMSTest, SquaredDistanceGreaterThanSquaredNMSRadius) {
   PoseKeypoints pose_keypoints[num_keypoints];
   pose_keypoints->keypoint[0] = Point{0, 0};
   pose_keypoints->keypoint[1] = Point{1, 1};
-  KeypointWithScore keypoint1(Point{0.5, 0.5}, /*id=*/0, /*score=*/0);
+  KeypointWithScore keypoint1(Point{0.5f, 0.5f}, /*id=*/0, /*score=*/0);
   // score doesn't matter here. Function doesn't check the score
   // The squared distance of this keypoint to previously detected keypoints is
   // min(0.5, 0.5) = 0.5
 
   EXPECT_TRUE(PassKeypointNMS(pose_keypoints, num_keypoints, keypoint1,
-                              /*squared_nms_radius=*/0.45));
+                              /*squared_nms_radius=*/0.45f));
 }
 
 TEST(FindOverlappingKeypointsTest, KeypointsResultNoOverlap) {
@@ -478,7 +478,7 @@ TEST(FindOverlappingKeypointsTest, KeypointsResultOverlap) {
   pose_keypoints1.keypoint[0] = Point{0, 0};
   pose_keypoints1.keypoint[1] = Point{1, 1};
   PoseKeypoints pose_keypoints2;
-  pose_keypoints2.keypoint[0] = Point{0, 0.9};
+  pose_keypoints2.keypoint[0] = Point{0, 0.9f};
   pose_keypoints2.keypoint[1] = Point{2, 2};
   std::vector<bool> mask(2, false);
 
@@ -497,8 +497,8 @@ std::vector<float> TestSoftKeypointNMS(const float squared_nms_radius,
       {Point{0, 1}, Point{2, 2}},
   };
   PoseKeypointScores all_keypoint_scores[] = {
-      {0.1, 0.2},
-      {0.3, 0.4},
+      {0.1f, 0.2f},
+      {0.3f, 0.4f},
   };
 
   // Set the second instance to be stronger than the first instance
@@ -522,15 +522,15 @@ TEST(PerformSoftKeypointNMSTest, PerformSoftKeypointNMSAverage) {
 
   // If 0 < squared_nms_radius < 1: {false, false}
   EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/0.9, /*topk=*/2),
-              Pointwise(FloatEq(), {0.15, 0.35}));
+              Pointwise(FloatEq(), {0.15f, 0.35f}));
 
   // If 1 < squared_nms_radius < 2: {true, false}
   EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/1.5, /*topk=*/2),
-              Pointwise(FloatEq(), {0.1, 0.35}));
+              Pointwise(FloatEq(), {0.1f, 0.35f}));
 
   // If 2 < squared_nms_radius: {true, true}
   EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/2.1, /*topk=*/2),
-              Pointwise(FloatEq(), {0.0, 0.35}));
+              Pointwise(FloatEq(), {0.0f, 0.35f}));
 }
 
 TEST(PerformSoftKeypointNMSTest, PerformSoftKeypointNMSMaximum) {
@@ -543,16 +543,16 @@ TEST(PerformSoftKeypointNMSTest, PerformSoftKeypointNMSMaximum) {
   // corresponding keypoints of the stronger instance
 
   // If 0 < squared_nms_radius < 1: {false, false}
-  EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/0.9, /*topk=*/1),
-              Pointwise(FloatEq(), {0.2, 0.4}));
+  EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/0.9f, /*topk=*/1),
+              Pointwise(FloatEq(), {0.2f, 0.4f}));
 
   // If 1 < squared_nms_radius < 2: {true, false}
-  EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/1.5, /*topk=*/1),
-              Pointwise(FloatEq(), {0.2, 0.4}));
+  EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/1.5f, /*topk=*/1),
+              Pointwise(FloatEq(), {0.2f, 0.4f}));
 
   // If 2 < squared_nms_radius: {true, true}
-  EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/2.1, /*topk=*/1),
-              Pointwise(FloatEq(), {0.0, 0.4}));
+  EXPECT_THAT(TestSoftKeypointNMS(/*squared_nms_radius=*/2.1f, /*topk=*/1),
+              Pointwise(FloatEq(), {0.0f, 0.4f}));
 }
 }  // namespace coral
 

--- a/src/cpp/test_utils.cc
+++ b/src/cpp/test_utils.cc
@@ -432,7 +432,7 @@ void TestDetection(const std::string& model_path, const std::string& image_path,
 void TestCatMsCocoDetection(const std::string& model_path,
                             float score_threshold, float iou_threshold) {
   TestDetection(model_path, TestDataPath("cat.bmp"),
-                /*expected_box=*/{0.1, 0.1, 0.7, 1.0},
+                /*expected_box=*/{0.1f, 0.1f, 0.7f, 1.0f},
                 /*expected_label=*/16, score_threshold, iou_threshold);
 }
 


### PR DESCRIPTION
I found `C2397`  error when compiling `edgetpu` on **Windwos,** 

`error C2397: conversion from 'double' to 'float' requires a narrowing conversion...`

So, I fix some test code which causes the problem.
