### PR TITLE
Fix minimal example to compile in Dev Board with Makefile

### DIFF
--- a/libedgetpu/direct/aarch64/libedgetpu.so
+++ b/libedgetpu/direct/aarch64/libedgetpu.so
@@ -1,0 +1,1 @@
+libedgetpu.so.1

--- a/src/cpp/examples/Makefile
+++ b/src/cpp/examples/Makefile
@@ -1,4 +1,5 @@
 # This is a Makefile to cross-compile minimal.cc example.
+# To compile in Dev Board with Mendel you must install libbenchmark-dev package
 # 1. Download TensorFlow to Linux machine:
 #    $ git clone https://github.com/tensorflow/tensorflow.git
 # 2. Download external dependencies for TensorFlow Lite:
@@ -16,15 +17,27 @@
 MAKEFILE_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 TENSORFLOW_DIR ?=
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	TARGET := linux
+else
+	TARGET := unknown
+endif
+
+TARGET_ARCH := $(shell uname -m)
+TARGET_OUT_DIR ?= $(TARGET)_$(TARGET_ARCH)
+
 minimal: minimal.cc model_utils.cc
 	aarch64-linux-gnu-g++ -std=c++11 -o minimal minimal.cc model_utils.cc \
 	-I$(MAKEFILE_DIR)/../../../ \
 	-I$(MAKEFILE_DIR)/../../../libedgetpu/ \
 	-I$(TENSORFLOW_DIR) \
+	-I$(TENSORFLOW_DIR)/tensorflow/lite/tools  \
 	-I$(TENSORFLOW_DIR)/tensorflow/lite/tools/make/downloads/flatbuffers/include \
-	-L$(TENSORFLOW_DIR)/tensorflow/lite/tools/make/gen/generic-aarch64_armv8-a/lib \
-	-L$(MAKEFILE_DIR)/../../../libedgetpu/direct/aarch64/ \
-	-ltensorflow-lite -l:libedgetpu.so.1.0 -lpthread -lm -ldl
+	-I$(TENSORFLOW_DIR)/tensorflow/lite/tools/make/downloads/absl \
+	-L$(TENSORFLOW_DIR)/tensorflow/lite/tools/make/gen/$(TARGET_OUT_DIR)/lib \
+	-L$(MAKEFILE_DIR)/../../../libedgetpu/direct/$(TARGET_ARCH) \
+	-lbenchmark -ltensorflow-lite -ledgetpu -lpthread -lm -ldl
 
 clean:
 	rm -f minimal

--- a/src/cpp/examples/minimal.cc
+++ b/src/cpp/examples/minimal.cc
@@ -14,6 +14,20 @@
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/model.h"
 
+
+
+namespace coral {
+    
+    std::string GetTempPrefix() {
+        const char* env_temp = getenv("TEMP");
+        if (env_temp) {
+            return env_temp;
+        } else {
+            return "/tmp";
+        }
+    }
+}
+
 std::vector<uint8_t> decode_bmp(const uint8_t* input, int row_size, int width,
                                 int height, int channels, bool top_down) {
   std::vector<uint8_t> output(height * width * channels);


### PR DESCRIPTION
The Makefile for minimal example don't work in Dev Board with Mendel distro .
With this patch you can compile the minimal application but don't work with edgetpu models in Dev Board

```
mendel@undefined-dog:~/coral/edgetpu/src/cpp/examples$  LD_LIBRARY_PATH=/home/mendel/coral/edgetpu/libedgetpu/direct/aarch64 ./minimal ~/coral/edgetpu/test_data/mobilenet_v1_1.0_224_quant_edgetpu.tflite ~/coral/edgetpu/test_data/resized_cat.bmp 
ERROR: Internal: Unsupported data type in custom op handler: -610837120
ERROR: Node number 0 (edgetpu-custom-op) failed to prepare.

Failed to allocate tensors.
Segmentation fault
```

But works with tflite models

```
LD_LIBRARY_PATH=/home/mendel/coral/edgetpu/libedgetpu/direct/aarch64 ./minimal
 ~/coral/edgetpu/test_data/mobilenet_v1_1.0_224_quant.tflite ~/coral/edgetpu/test_data/resized_cat.bmp
[Image analysis] max value index: 286 value: 0.804688
```

The models works with python demos

```
mendel@undefined-dog:~/coral/tflite/python/examples/classification$ LD_LIBRARY_PATH=/home/mendel/coral/edgetpu/libedgetpu/direct/aarch64 python3 classify_image.py --model ~/coral/edgetpu/test_data/mobilenet_v1_1.0_224_quant_edgetpu.tflite --input  ~/coral/edgetpu/test_data/resized_cat.bmp 
----INFERENCE TIME----
Note: The first inference on Edge TPU is slow because it includes loading the model into Edge TPU memory.
14.6ms
2.3ms
2.3ms
2.3ms
2.3ms
-------RESULTS--------
286: 0.79297
```



